### PR TITLE
Reliable News Feed 

### DIFF
--- a/webapp/src/CardsArray.js
+++ b/webapp/src/CardsArray.js
@@ -5,6 +5,7 @@ import * as Util from './Shared/Util.js'
 import { CardResourceTypes, Emotions } from './Shared/Enums'
 import { SheetsUrl, NewsApi } from './Shared/Constants'
 import NewsCardComponent from './MinorComponents/NewsCardComponent'
+import SwitchBase from '@material-ui/core/internal/SwitchBase';
 
 //number of categories asked for on any one path of the form
 const numberOfCategories = 7;
@@ -191,7 +192,23 @@ class CardsArray extends React.Component {
                 timePublished: time,
                 source: data2['articles'][i]['source']['name'], 
             }
-            tmpNews.push(dictData)
+
+            //modified the api request string to return 100 results and only use one request 
+            //The following reliable news sources will be the only ones used on the live news feed
+            //CBS, Wall Street Journal, CNN, ABC, FOX, Google News, NBC, Reuters, Tech Crunch, Tech Radar,
+            //USA Today, TIME, Next Big Future, AP, Bloomberg, Axios, Business Insider
+              
+            if((dictData['url'].includes("www.cbsnews.com")) || (dictData['url'].includes("www.wsj.com")) || (dictData['url'].includes("www.cnn.com"))
+            || (dictData['url'].includes("www.abcnews.go.com")) || (dictData['url'].includes("www.foxnews.com")) || (dictData['url'].includes("www.news.google.com")) 
+            || (dictData['url'].includes("www.nbcnews.com")) || (dictData['url'].includes("www.reuters.com")) || (dictData['url'].includes("www.techcrunch.com")) 
+            || (dictData['url'].includes("www.techradar.com")) || (dictData['url'].includes("www.usatoday.com")) || (dictData['url'].includes("www.time.com"))
+            || (dictData['url'].includes("www.washingtontimes.com")) || (dictData['url'].includes("www.wired.com")) || (dictData['url'].includes("www.news.vice.com")) 
+            || (dictData['url'].includes("www.nextbigfuture.com")) || (dictData['url'].includes("www.apnews.com")) || (dictData['url'].includes("www.bloomberg.com")) 
+            || (dictData['url'].includes("www.axios.com")) || (dictData['url'].includes("www.businessinsider.com")))
+            {
+              tmpNews.push(dictData)
+            }
+            
           }
         }
 

--- a/webapp/src/Shared/Constants.js
+++ b/webapp/src/Shared/Constants.js
@@ -1,3 +1,9 @@
 export const SheetsUrl = "https://spreadsheets.google.com/feeds/cells/187Oua2qj26uUd6lRYbuJoSVHw8-OGC9QvKvJfEewnkA/1/public/full?alt=json"
 
-export const NewsApi = "https://newsapi.org/v2/top-headlines?q=coronavirus&language=en&page=1&apiKey=e377370ade7c4b1eb951323b8740372f"
+export const NewsApi = "https://newsapi.org/v2/top-headlines?q=coronavirus&sortBy=datePublished&pageSize=100&language=en&apiKey=e377370ade7c4b1eb951323b8740372f"
+//https://newsapi.org/v2/everything?q=coronavirus&domains=wsj.com,%20cnn.com,%20abcnews.go.com,%20apnews.com,%20axios.com,%20bloomberg.com,%20businessinsider.com,%20cbsnews.com,%20cnbc.com,%20foxnews.com,%20news.google.com,%20nbcnews.com,%20nextbigfuture.com,%20reuters.com,%20techcrunch.com,%20techradar.com,%20washingtontimes.com,%20time.com,%20usatoday.com/news,%20news.vice.com,%20wired.com&sortBy=datePublished&pageSize=100&page=1&apiKey=e377370ade7c4b1eb951323b8740372f"
+//https://newsapi.org/v2/everything?q=coronavirus&domains=wsj.com,%20cnn.com,%20abcnews.go.com,%20apnews.com,%20axios.com,%20bloomberg.com,%20businessinsider.com,%20cbsnews.com,%20cnbc.com,%20foxnews.com,%20news.google.com,%20nbcnews.com,%20nextbigfuture.com,%20reuters.com,%20techcrunch.com,%20techradar.com,%20washingtontimes.com,%20time.com,%20usatoday.com/news,%20news.vice.com,%20wired.com&sortBy=popular&page=2&apiKey=e377370ade7c4b1eb951323b8740372f"
+
+//https://newsapi.org/v2/top-headlines?q=coronavirus&language=en&page=1&apiKey=e377370ade7c4b1eb951323b8740372f"
+
+//https://newsapi.org/v2/everything?q=coronavirus&domains=wsj.com, cnn.com, abcnews.go.com, apnews.com, axios.com, bloomberg.com, businessinsider.com, cbsnews.com, cnbc.com, foxnews.com, news.google.com, nbcnews.com, nextbigfuture.com, reuters.com, techcrunch.com, techradar.com, washingtontimes.com, time.com, usatoday.com/news, news.vice.com, wired.com&sortBy=datePublished&page=1&apiKey=e377370ade7c4b1eb951323b8740372f


### PR DESCRIPTION
The following reliable news sources will be the only ones used on the live news feed:
           CBS, Wall Street Journal, CNN, ABC, FOX, Google News, NBC, Reuters, Tech Crunch, Tech Radar, USA Today, TIME, Next Big Future, AP, Bloomberg, Axios, Business Insider